### PR TITLE
M7: add weekly docs skeleton (refs #7)

### DIFF
--- a/docs/weekly/2025-08-18-m7.md
+++ b/docs/weekly/2025-08-18-m7.md
@@ -1,0 +1,21 @@
+This week I captured live-session requirements, organized them into GitHub issues, and planned the dev→stage workflow.
+
+## Requirements Captured
+- #6 Capture Live-sessions requirements
+- #7 Update docs weekly with summary of decisions
+- #8 Prepare PRs and merge dev → stage for milestone 7
+
+## Changes Implemented
+- Created Milestone 7 and seeded issues
+- Set up M7 Sprint board view
+- Added weekly docs skeleton
+
+## Testing & Evidence
+- PRs: (add links after opening)
+- Screenshots: (board + milestone)
+- Commits: (SHAs after merge)
+
+## Decisions & Follow-ups
+- Open feature PR(s) into `dev`
+- Tracking PR `dev` → `stage` after checks
+- Add screenshots and finalize evidence


### PR DESCRIPTION
Summary
Adds Milestone 7 weekly docs skeleton at docs/weekly/2025-08-18-m7.md

Changes
- New weekly note with sections: Summary, Requirements Captured, Changes Implemented,
  Testing & Evidence, Decisions & Follow-ups

Evidence
- Screenshot: Milestone & M7 board (attached)

Closes #7
<img width="1205" height="919" alt="Screenshot 2025-08-18 at 8 10 37 PM" src="https://github.com/user-attachments/assets/5872f746-6101-4d0e-bab9-9bc80421ce74" />
<img width="1203" height="915" alt="Screenshot 2025-08-18 at 8 11 13 PM" src="https://github.com/user-attachments/assets/ca87990d-ff4d-4a03-a2da-8162547cc014" />
